### PR TITLE
Entities method __toString() always return string type

### DIFF
--- a/Entity/Term.php
+++ b/Entity/Term.php
@@ -82,7 +82,7 @@ class Term
 
     public function __toString()
     {
-        return $this->name;
+        return (string) $this->name;
     }
 
     /**

--- a/Entity/Vocabulary.php
+++ b/Entity/Vocabulary.php
@@ -74,7 +74,7 @@ class Vocabulary
      */
     public function __toString()
     {
-        return $this->getLabel();
+        return (string) $this->getLabel();
     }
 
     /**


### PR DESCRIPTION
There is problem when using Sonata Admin. Create form requires string value to be returned from __toString() method. For a new object it's now always null.